### PR TITLE
Fix:fixed logic to sort documents by 'date' for 'NEWS' type and 'crea…

### DIFF
--- a/BE/src/main/java/com/resengkor/management/domain/document/repository/DocumentRepository.java
+++ b/BE/src/main/java/com/resengkor/management/domain/document/repository/DocumentRepository.java
@@ -5,6 +5,8 @@ import com.resengkor.management.domain.document.entity.DocumentType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,8 +14,8 @@ import java.util.Optional;
 @Repository
 public interface DocumentRepository extends JpaRepository<DocumentEntity, Long> {
     //카테고리에 따른 목록 조회
-    @Query("SELECT d FROM DocumentEntity d WHERE d.type = :type " +
-            "ORDER BY CASE WHEN :type = 'NEWS' THEN d.date ASC ELSE d.createdAt DESC END"
+//    @Query("SELECT d FROM DocumentEntity d WHERE d.type = :type " +
+//            "ORDER BY CASE WHEN :type = 'NEWS' THEN d.date ASC ELSE d.createdAt DESC END")
     Page<DocumentEntity> findByType(@Param("type") DocumentType type, Pageable pageable);
 
     // Document ID와 Type을 기준으로 문서 조회(세부)

--- a/BE/src/main/java/com/resengkor/management/domain/document/service/DocumentService.java
+++ b/BE/src/main/java/com/resengkor/management/domain/document/service/DocumentService.java
@@ -119,7 +119,8 @@ public class DocumentService {
 
     //조회
     public DataResponse<Page<DocumentResponse>> getDocumentList(String documentType,int page, int size) {
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC,
+                documentType.equalsIgnoreCase("NEWS") ? "date" : "createdAt"));
         Page<DocumentEntity> documentPage = documentRepository.findByType(DocumentType.valueOf(documentType.toUpperCase()), pageRequest);
 
         Page<DocumentResponse> documentResponsePage = documentPage.map(DocumentResponse::fromEntity);


### PR DESCRIPTION
…tedAt' for other types.